### PR TITLE
Add an option to select locale from a list of languages.

### DIFF
--- a/src/app/src/main/java/io/github/lonamiwebs/stringlate/activities/translate/LocaleListBuilder.java
+++ b/src/app/src/main/java/io/github/lonamiwebs/stringlate/activities/translate/LocaleListBuilder.java
@@ -1,0 +1,97 @@
+package io.github.lonamiwebs.stringlate.activities.translate;
+
+import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
+import android.widget.TextView;
+
+import java.util.Comparator;
+import java.util.Locale;
+
+import io.github.lonamiwebs.stringlate.R;
+
+/**
+ * Created by stani on 2017-03-04.
+ *
+ * This class creates a simple AlertDialog with a list of locales.
+ * Use the callback method to retrieve the selected locale.
+ */
+public class LocaleListBuilder {
+
+    private final AlertDialog mDialog;
+
+    /**
+     *
+     * @param activity
+     * @param cb - use this to retrieve the selected locale
+     */
+    public LocaleListBuilder(final Activity activity, final LocalePickCallback cb) {
+
+        final Locale[] locales = Locale.getAvailableLocales();
+        final LocaleArrayAdapter arrayAdapter =
+                new LocaleArrayAdapter(activity, R.layout.item_locale_list, locales);
+        arrayAdapter.sort(new Comparator<Locale>() {
+            @Override
+            public int compare(final Locale o1, final Locale o2) {
+                final String lang1 = o1.getDisplayLanguage();
+                final String lang2 = o2.getDisplayLanguage();
+                return lang1.compareTo(lang2);
+            }
+        });
+
+        final DialogInterface.OnClickListener clickListener =
+                new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        String localeCode = locales[which].getLanguage();
+                        cb.onChoice(localeCode);
+                    }
+                };
+
+        mDialog = new AlertDialog.Builder(activity)
+                .setTitle(R.string.choose_locale_from_list)
+                .setNegativeButton(R.string.cancel, null)
+                .setAdapter(arrayAdapter,clickListener).create();
+    }
+
+    public void show() {
+        mDialog.show();
+    }
+
+    private class LocaleArrayAdapter extends ArrayAdapter<Locale> {
+
+        final int mResource;
+        public LocaleArrayAdapter(final Context context, final int resource, final Locale[] locales) {
+            super(context, resource, locales);
+            mResource = resource;
+        }
+
+        @Override
+        public View getView(final int position, final View view, final ViewGroup parent) {
+            final Locale locale = this.getItem(position);
+            final View convertView;
+            if (view == null) {
+                convertView = LayoutInflater.from(getContext()).inflate(mResource, parent, false);
+            } else {
+                convertView = view;
+            }
+
+            TextView tvLangName = (TextView) convertView.findViewById(R.id.language_name);
+            TextView tvLangCode = (TextView) convertView.findViewById(R.id.language_code);
+
+            tvLangCode.setText(locale.getLanguage());
+            tvLangName.setText(locale.getDisplayName());
+
+            return convertView;
+        }
+    }
+
+    public interface LocalePickCallback {
+        void onChoice(String localeCode);
+    }
+}

--- a/src/app/src/main/java/io/github/lonamiwebs/stringlate/activities/translate/TranslateActivity.java
+++ b/src/app/src/main/java/io/github/lonamiwebs/stringlate/activities/translate/TranslateActivity.java
@@ -375,14 +375,34 @@ public class TranslateActivity extends AppCompatActivity {
 
     //region Adding locales menu events
 
+    private void promptAddLocale() {
+        promptAddLocale("");
+    }
+
     // Prompts the user to add a new locale. If it exists,
     // no new file is created but the entered locale is selected.
-    private void promptAddLocale() {
+    private void promptAddLocale(final String presetLocaleCode) {
+
+        final LocaleListBuilder localeList = new LocaleListBuilder(this,
+                new LocaleListBuilder.LocalePickCallback(){
+                    @Override
+                    public void onChoice(final String localeCode) {
+                        promptAddLocale(localeCode);
+                    }
+                });
+
         final EditText et = new EditText(this);
+        et.setText(presetLocaleCode);
         new AlertDialog.Builder(this)
                 .setTitle(R.string.enter_locale)
                 .setMessage(getString(R.string.enter_locale_long, Locale.getDefault().getLanguage()))
                 .setView(et)
+                .setNeutralButton(R.string.choose_locale_from_list, new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        localeList.show();
+                    }
+                })
                 .setPositiveButton(R.string.create, new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialogInterface, int i) {

--- a/src/app/src/main/res/layout/item_locale_list.xml
+++ b/src/app/src/main/res/layout/item_locale_list.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical" android:layout_width="match_parent"
+    android:paddingTop="15dp"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textAppearance="?android:attr/textAppearanceMedium"
+        android:text="Large Text"
+        android:id="@+id/language_name" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textAppearance="?android:attr/textAppearanceSmall"
+        android:text="Small Text"
+        android:id="@+id/language_code" />
+
+</LinearLayout>

--- a/src/app/src/main/res/values/strings.xml
+++ b/src/app/src/main/res/values/strings.xml
@@ -29,6 +29,7 @@
     <string name="add_locale_to_start">Add a new locale to get started.</string>
     <string name="enter_locale">Enter locale name</string>
     <string name="enter_locale_long">Enter the locale name for which the strings.xml file will be created (your current locale is \"%s\"):</string>
+    <string name="choose_locale_from_list">Choose locale from list</string>
     <string name="create">Create</string>
     <string name="cancel">Cancel</string>
     <string name="create_locale_error">Could not create the new locale file.</string>


### PR DESCRIPTION
I added a simple list of languages to the 'Add new locale' dialog, which translators can use to select a locale without having to remember the locale code.