### PR TITLE
Improve string ref recognition

### DIFF
--- a/src/app/src/main/java/io/github/lonamiwebs/stringlate/classes/resources/Resources.java
+++ b/src/app/src/main/java/io/github/lonamiwebs/stringlate/classes/resources/Resources.java
@@ -203,7 +203,7 @@ public class Resources implements Iterable<ResTag> {
 
     // To be used by the ResourcesParser
     void loadTag(ResTag rt) {
-        if (rt.getContent().startsWith("@"))
+        if (rt.getContent().startsWith("@string/") || rt.getContent().startsWith("@android:string/"))
             mReferenceStrings.put(rt.getId(), rt);
         else
             mStrings.put(rt.getId(), rt);


### PR DESCRIPTION
`@android:string/` (e.g. `@android:string/ok`) are e.g. also some common string refs.