### PR TITLE
Nicely declare permissions for aapt. Fixes an issue with installing from F-Droid

### DIFF
--- a/src/app/src/main/AndroidManifest.xml
+++ b/src/app/src/main/AndroidManifest.xml
@@ -6,7 +6,12 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <uses-permission
-        android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="21" />
+
+    <uses-permission
+        android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="21" />
 
     <application
         android:allowBackup="true"


### PR DESCRIPTION
@Lonami It fixes https://gitlab.com/fdroid/fdroidclient/issues/951 without requesting `WRITE_EXTERNAL_STORAGE` on newer APIs. The issue is with aapt: https://gitlab.com/fdroid/fdroidclient/issues/951#note_27591556