### PR TITLE
Fix hardcoded and not translatable strings

### DIFF
--- a/src/app/src/main/res/values-ru/strings.xml
+++ b/src/app/src/main/res/values-ru/strings.xml
@@ -153,11 +153,13 @@
     <string name="more_info_on_how_to_contribute_to_this_project">Больше информации о том как внести свой вклад в этот проект</string>
     <string name="contribute_code_to_this_project_anybody_welcome">Вкладывайте свой код в проект. Все желающие приветствуются, включая новичков</string>
     <string name="project_team">Команда проекта</string>
+    <string name="community">Сообщество</string>
     <string name="licenses">Лицензии</string>
     <string name="contributors">Авторы</string>
     <string name="donate">Поддержать</string>
     <string name="contribute">Внести вклад</string>
     <string name="view">Просмотр</string>
     <string name="editing_font">Шрифт редактора</string>
+    <string name="copy_build_information">Копировать информацию о сборке</string>
 
 </resources>

--- a/src/app/src/main/res/values/strings-not_translatable.xml
+++ b/src/app/src/main/res/values/strings-not_translatable.xml
@@ -56,5 +56,4 @@
     <string name="pref_key__more_info__project_team" translatable="false">pref_key__more_info__project_team</string>
     <string name="pref_key__more_info__contributors_public_info" translatable="false">pref_key__more_info__contributors_public_info</string>
     <string name="pref_key__more_info__copy_build_information" translatable="false">pref_key__more_info__copy_build_information</string>
-    <string name="community" translatable="false">Community</string>
 </resources>

--- a/src/app/src/main/res/values/strings.xml
+++ b/src/app/src/main/res/values/strings.xml
@@ -153,6 +153,7 @@
     <string name="more_info_on_how_to_contribute_to_this_project">More info on how to contribute to this project</string>
     <string name="contribute_code_to_this_project_anybody_welcome">Contribute code to the project. Everybody is welcome to do so, including newcomers</string>
     <string name="project_team">Project Team</string>
+    <string name="community">Community</string>
     <string name="licenses">Licenses</string>
     <string name="contributors">Contributors</string>
     <string name="donate">Donate</string>

--- a/src/app/src/main/res/values/strings.xml
+++ b/src/app/src/main/res/values/strings.xml
@@ -160,5 +160,6 @@
     <string name="contribute">Contribute</string>
     <string name="view">View</string>
     <string name="editing_font">Editing font</string>
+    <string name="copy_build_information">Copy build information</string>
 
 </resources>

--- a/src/app/src/main/res/xml/prefactions__more_information.xml
+++ b/src/app/src/main/res/xml/prefactions__more_information.xml
@@ -114,7 +114,7 @@
         <Preference
             android:icon="@drawable/ic_code_black_24dp"
             android:key="@string/pref_key__more_info__copy_build_information"
-            android:title="Copy build information" />
+            android:title="@string/copy_build_information" />
 
     </PreferenceCategory>
 


### PR DESCRIPTION
Made "community" string translatable and extracted hardcoded "Copy build information" string.

Also added russian translation for these strings.